### PR TITLE
Add D-Bus methods for window state RPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-all: all-windows@ezix.org.shell-extension.zip
+all: all-windows-srwp@jkavery.github.io.shell-extension.zip schemas/gschemas.compiled
 
-all-windows@ezix.org.shell-extension.zip: COPYING README.md extension.js favicon.png favicon.svg metadata.json
+all-windows-srwp@jkavery.github.io.shell-extension.zip: COPYING README.md extension.js favicon.png favicon.svg metadata.json
 	gnome-extensions pack --force $$(for f in $^; do echo --extra-source=$$f; done)
+
+schemas/gschemas.compiled: schemas/org.gnome.shell.extensions.all-windows-srwp.gschema.xml
+	glib-compile-schemas schemas/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The All Windows functionality is a port by lyonel of his Cinnamon applet (now in
 
 It displays a menu listing all open windows on all workspaces on the right-hand side of the GNOME top bar and allows quickly switching between them.
 
+Additionally, it exposes save/restore window positions as [D-Bus](https://www.freedesktop.org/wiki/Software/dbus/) methods.
+
 Save/Restore window positions additional functionality
 ------------------------------------------------------
 At the top of the menu, preceding the listing of open windows, are two buttons: *Save window positions* and *Restore window positions*.
@@ -14,6 +16,19 @@ At the top of the menu, preceding the listing of open windows, are two buttons: 
 The buttons are used to remember and restore the positions of the open windows in the display.  The set of window positions is associated with the current display size, which can change when monitors are added or removed.  Each display size has its own set of window positions.
 
 In addition, window positions are automatically saved when the computer is suspended and restored when it is resumed.  This provides a workaround for [Bug #1778983 “Resume from suspend on Wayland breaks window positioning” : Bugs : mutter package : Ubuntu](https://bugs.launchpad.net/ubuntu/+source/mutter/+bug/1778983).  The problem remains in Ubuntu 22.04.
+
+### RPC
+
+This extension exposes two D-Bus methods: `org.gnome.Shell.Extensions.AllWindows.SaveSession` and `org.gnome.Shell.Extensions.AllWindows.RestoreSession`. You can call them in scripts using
+
+```bash
+gdbus call --session \
+  --dest org.gnome.Shell \
+  --object-path /org/gnome/Shell/Extensions/AllWindows \
+  --method org.gnome.Shell.Extensions.AllWindows.METHOD
+```
+
+Where `METHOD` is one of `SaveSession` or `RestoreSession`.
 
 ### Limitations
  * Restore does not manage which windows are on top.  However, in testing to date the correct windows have always been shown on top.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,38 @@ Compatibility
 -------------
 This extension has been tested on GNOME 49 and 50.
 
+Testing
+-------
+
+These are Randy's notes about testing the addition of method calls. The way to
+test extensions on Wayland is to make a nested `gnome-shell` and interact with
+the extension via `gdbus`:
+
+First, install the development extension:
+
+1. Run `make` to compile schemas
+2. Find the extension directory under `~/.local/share/gnome-shell/extensions/`
+3. Delete it and create a soft link to your development repository with `ln -sf ~/git/all-windows ~/.local/share/gnome-shell/extensions/all-windows-srwp@jkavery.github.io`
+
+Then, set up a nested shell and test:
+
+```bash
+# 1. Enter the subshell container
+dbus-run-session -- zsh
+
+# 2. Start the headless engine in the background
+gnome-shell --devkit --wayland --headless --virtual-monitor 1024x768 &
+
+# 3. Make sure the extension is enabled 
+gnome-extensions enable all-windows-srwp@jkavery.github.io
+
+# 4. Trigger a method call. We can use console.log in the method to confirm
+gdbus call --session \
+  --dest org.gnome.Shell \
+  --object-path /org/gnome/Shell/Extensions/AllWindows \
+  --method org.gnome.Shell.Extensions.AllWindows.SaveSession
+```
+
 License
 -------
 This extension is released under the GNU Public License version 2.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In addition, window positions are automatically saved when the computer is suspe
 
 ### RPC
 
-This extension exposes two D-Bus methods: `org.gnome.Shell.Extensions.AllWindows.SaveSession` and `org.gnome.Shell.Extensions.AllWindows.RestoreSession`. You can call them in scripts using
+This extension exposes two D-Bus methods: `org.gnome.Shell.Extensions.AllWindows.SavePositions` and `org.gnome.Shell.Extensions.AllWindows.RestorePositions`. You can call them in scripts using
 
 ```bash
 gdbus call --session \
@@ -28,7 +28,7 @@ gdbus call --session \
   --method org.gnome.Shell.Extensions.AllWindows.METHOD
 ```
 
-Where `METHOD` is one of `SaveSession` or `RestoreSession`.
+Where `METHOD` is one of `SavePositions` or `RestorePositions`.
 
 ### Limitations
  * Restore does not manage which windows are on top.  However, in testing to date the correct windows have always been shown on top.
@@ -80,7 +80,7 @@ gnome-extensions enable all-windows-srwp@jkavery.github.io
 gdbus call --session \
   --dest org.gnome.Shell \
   --object-path /org/gnome/Shell/Extensions/AllWindows \
-  --method org.gnome.Shell.Extensions.AllWindows.SaveSession
+  --method org.gnome.Shell.Extensions.AllWindows.SavePositions
 ```
 
 We can also tail the journal to see log messages with

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This extension has been tested on GNOME 49 and 50.
 Testing
 -------
 
-These are Randy's notes about testing the addition of method calls. The way to
+These are @thisisrandy's notes about testing the addition of method calls. The way to
 test extensions on Wayland is to make a nested `gnome-shell` and interact with
 the extension via `gdbus`:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In addition, window positions are automatically saved when the computer is suspe
 
 ### RPC
 
-This extension exposes two D-Bus methods: `org.gnome.Shell.Extensions.AllWindows.SaveWindows` and `org.gnome.Shell.Extensions.AllWindows.RestoreWindows`. You can call them in scripts using
+This extension exposes two D-Bus methods: `org.gnome.Shell.Extensions.AllWindows.SaveSession` and `org.gnome.Shell.Extensions.AllWindows.RestoreSession`. You can call them in scripts using
 
 ```bash
 gdbus call --session \
@@ -28,7 +28,7 @@ gdbus call --session \
   --method org.gnome.Shell.Extensions.AllWindows.METHOD
 ```
 
-Where `METHOD` is one of `SaveWindows` or `RestoreWindows`.
+Where `METHOD` is one of `SaveSession` or `RestoreSession`.
 
 ### Limitations
  * Restore does not manage which windows are on top.  However, in testing to date the correct windows have always been shown on top.
@@ -80,7 +80,7 @@ gnome-extensions enable all-windows-srwp@jkavery.github.io
 gdbus call --session \
   --dest org.gnome.Shell \
   --object-path /org/gnome/Shell/Extensions/AllWindows \
-  --method org.gnome.Shell.Extensions.AllWindows.SaveWindows
+  --method org.gnome.Shell.Extensions.AllWindows.SaveSession
 ```
 
 We can also tail the journal to see log messages with

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ gdbus call --session \
   --method org.gnome.Shell.Extensions.AllWindows.SaveSession
 ```
 
+We can also tail the journal to see log messages with
+
+```
+journalctl --user -f -o cat /usr/bin/gnome-shell
+```
+
 License
 -------
 This extension is released under the GNU Public License version 2.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In addition, window positions are automatically saved when the computer is suspe
 
 ### RPC
 
-This extension exposes two D-Bus methods: `org.gnome.Shell.Extensions.AllWindows.SaveSession` and `org.gnome.Shell.Extensions.AllWindows.RestoreSession`. You can call them in scripts using
+This extension exposes two D-Bus methods: `org.gnome.Shell.Extensions.AllWindows.SaveWindows` and `org.gnome.Shell.Extensions.AllWindows.RestoreWindows`. You can call them in scripts using
 
 ```bash
 gdbus call --session \
@@ -28,7 +28,7 @@ gdbus call --session \
   --method org.gnome.Shell.Extensions.AllWindows.METHOD
 ```
 
-Where `METHOD` is one of `SaveSession` or `RestoreSession`.
+Where `METHOD` is one of `SaveWindows` or `RestoreWindows`.
 
 ### Limitations
  * Restore does not manage which windows are on top.  However, in testing to date the correct windows have always been shown on top.
@@ -80,7 +80,7 @@ gnome-extensions enable all-windows-srwp@jkavery.github.io
 gdbus call --session \
   --dest org.gnome.Shell \
   --object-path /org/gnome/Shell/Extensions/AllWindows \
-  --method org.gnome.Shell.Extensions.AllWindows.SaveSession
+  --method org.gnome.Shell.Extensions.AllWindows.SaveWindows
 ```
 
 We can also tail the journal to see log messages with

--- a/extension.js
+++ b/extension.js
@@ -23,8 +23,8 @@ import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 const AllWindowsIface = `
 <node>
   <interface name="org.gnome.Shell.Extensions.AllWindows">
-    <method name="SaveSession" />
-    <method name="RestoreSession" />
+    <method name="SavePositions" />
+    <method name="RestorePositions" />
   </interface>
 </node>`;
 
@@ -613,15 +613,15 @@ export default class AllWindowsExtension extends Extension {
         this.#log = null;
     }
 
-    async SaveSession() {
-        await this.#allWindowsStates.saveWindowPositions("DBus SaveSession").catch(e => {
-            this.#log.exception("SaveSession caught", e);
+    async SavePositions() {
+        await this.#allWindowsStates.saveWindowPositions("DBus SavePositions").catch(e => {
+            this.#log.exception("SavePositions caught", e);
         });
     }
 
-    async RestoreSession() {
-        await this.#allWindowsStates.restoreWindowPositions("DBus RestoreSession").catch(e => {
-            this.#log.exception("RestoreSession caught", e);
+    async RestorePositions() {
+        await this.#allWindowsStates.restoreWindowPositions("DBus RestorePositions").catch(e => {
+            this.#log.exception("RestorePositions caught", e);
         });
     }
 }

--- a/extension.js
+++ b/extension.js
@@ -616,12 +616,14 @@ export default class AllWindowsExtension extends Extension {
     }
 
     async SaveSession() {
-        this.#log.log("Saving window states...")
-        await this.#allWindowsStates.saveWindowPositions("SaveSession triggered via DBus")
+        await this.#allWindowsStates.saveWindowPositions("DBus SaveSession").catch(e => {
+            this.#log.exception("SaveSession caught", e);
+        });
     }
 
     async RestoreSession() {
-        this.#log.log("Restoring window states...")
-        await this.#allWindowsStates.restoreWindowPositions("RestoreSession triggered via DBus", this.#log)
+        await this.#allWindowsStates.restoreWindowPositions("DBus RestoreSession").catch(e => {
+            this.#log.exception("RestoreSession caught", e);
+        });
     }
 }

--- a/extension.js
+++ b/extension.js
@@ -459,12 +459,12 @@ class WindowList extends PanelMenu.Button {
         let tracker = Shell.WindowTracker.get_default();
         {
             let item = new PopupMenu.PopupMenuItem('Save window positions');
-            item.connect('activate', () => this._allWindowsStates.saveWindowPositions('Save')
+            item.connect('activate', () => this._allWindowsStates.saveWindowPositions('Menu Save')
                          .catch (e => {this._log.exception("Save menu item caught", e);}));
             this.menu.addMenuItem(item);
 
             item = new PopupMenu.PopupMenuItem('Restore window positions');
-            item.connect('activate', () => this._allWindowsStates.restoreWindowPositions('Restore', this._log)
+            item.connect('activate', () => this._allWindowsStates.restoreWindowPositions('Menu Restore', this._log)
                          .catch (e => {this._log.exception("Restore menu item caught", e);}));
             this.menu.addMenuItem(item);
 

--- a/extension.js
+++ b/extension.js
@@ -400,6 +400,8 @@ class AllWindowsStates {
             if (this.#log.infop)
                 this.#log.log(`Save ${state}`);
         }
+        if (this.#log.infop)
+            this.#log.log(`${why} is done`)
     }
 
     async restoreWindowPositions(why, log) {

--- a/extension.js
+++ b/extension.js
@@ -614,10 +614,12 @@ export default class AllWindowsExtension extends Extension {
     }
 
     SaveSession() {
-        console.log("D-Bus triggered: Saving Session")
+        console.log("Saving window states...")
+        this.#allWindowsStates.saveWindowPositions("SaveSession triggered via DBus")
     }
 
     RestoreSession() {
-        console.log("D-Bus triggered: Restoring Session")
+        console.log("Restoring window states...")
+        this.#allWindowsStates.restoreWindowPositions("RestoreSession triggered via DBus")
     }
 }

--- a/extension.js
+++ b/extension.js
@@ -23,8 +23,8 @@ import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 const AllWindowsIface = `
 <node>
   <interface name="org.gnome.Shell.Extensions.AllWindows">
-    <method name="SavePositions" />
-    <method name="RestorePositions" />
+    <method name="SaveSession" />
+    <method name="RestoreSession" />
   </interface>
 </node>`;
 

--- a/extension.js
+++ b/extension.js
@@ -613,15 +613,15 @@ export default class AllWindowsExtension extends Extension {
         this.#log = null;
     }
 
-    async SaveSession() {
-        await this.#allWindowsStates.saveWindowPositions("DBus SaveSession").catch(e => {
-            this.#log.exception("SaveSession caught", e);
+    async SavePositions(){
+        await this.#allWindowsStates.saveWindowPositions("DBus SavePositions").catch(e => {
+            this.#log.exception("SavePositions caught", e);
         });
     }
 
-    async RestoreSession() {
-        await this.#allWindowsStates.restoreWindowPositions("DBus RestoreSession").catch(e => {
-            this.#log.exception("RestoreSession caught", e);
+    async RestorePositions() {
+        await this.#allWindowsStates.restoreWindowPositions("DBus RestorePositions").catch(e => {
+            this.#log.exception("RestorePositions caught", e);
         });
     }
 }

--- a/extension.js
+++ b/extension.js
@@ -23,8 +23,8 @@ import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 const AllWindowsIface = `
 <node>
   <interface name="org.gnome.Shell.Extensions.AllWindows">
-    <method name="SaveSession" />
-    <method name="RestoreSession" />
+    <method name="SavePositions" />
+    <method name="RestorePositions" />
   </interface>
 </node>`;
 

--- a/extension.js
+++ b/extension.js
@@ -19,6 +19,15 @@ import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
   It adds save/restore window posiitons functionality.
 */
 
+// Define the DBus layout using standard introspection XML format
+const AllWindowsIface = `
+<node>
+  <interface name="org.gnome.Shell.Extensions.AllWindows">
+    <method name="SaveSession" />
+    <method name="RestoreSession" />
+  </interface>
+</node>`;
+
 // The following are only used for logging
 const EXTENSION_LOG_NAME = 'All Windows SRWP';
 const START_TIME = GLib.DateTime.new_now_local().format_iso8601();
@@ -572,6 +581,7 @@ export default class AllWindowsExtension extends Extension {
     #log;
     #allWindowsStates
     #windowlist
+    #dbusImpl
 
     constructor(metadata) {
         super(metadata);
@@ -583,6 +593,8 @@ export default class AllWindowsExtension extends Extension {
         this.#allWindowsStates = new AllWindowsStates(this.metadata.uuid, this.#log);
         this.#windowlist = new WindowList(this.#allWindowsStates, this.metadata, this.#log);
         Main.panel.addToStatusArea(this.uuid, this.#windowlist, -1, 'right');
+        this.#dbusImpl = Gio.DBusExportedObject.wrapJSObject(AllWindowsIface, this);
+        this.#dbusImpl.export(Gio.DBus.session, '/org/gnome/Shell/Extensions/AllWindows')
         this.#log.debug("enable() ending");
     }
 
@@ -592,7 +604,20 @@ export default class AllWindowsExtension extends Extension {
         this.#windowlist = null;
         this.#allWindowsStates?.destroy();
         this.#allWindowsStates = null;
+        if (this.#dbusImpl) {
+            this.#dbusImpl.flush()
+            this.#dbusImpl.unexport();
+            this.#dbusImpl = null;
+        }
         this.#log.debug("disable() ending");
         this.#log = null;
+    }
+
+    SaveSession() {
+        console.log("D-Bus triggered: Saving Session")
+    }
+
+    RestoreSession() {
+        console.log("D-Bus triggered: Restoring Session")
     }
 }

--- a/extension.js
+++ b/extension.js
@@ -613,15 +613,15 @@ export default class AllWindowsExtension extends Extension {
         this.#log = null;
     }
 
-    async SavePositions(){
-        await this.#allWindowsStates.saveWindowPositions("DBus SavePositions").catch(e => {
-            this.#log.exception("SavePositions caught", e);
+    async SaveSession() {
+        await this.#allWindowsStates.saveWindowPositions("DBus SaveSession").catch(e => {
+            this.#log.exception("SaveSession caught", e);
         });
     }
 
-    async RestorePositions() {
-        await this.#allWindowsStates.restoreWindowPositions("DBus RestorePositions").catch(e => {
-            this.#log.exception("RestorePositions caught", e);
+    async RestoreSession() {
+        await this.#allWindowsStates.restoreWindowPositions("DBus RestoreSession").catch(e => {
+            this.#log.exception("RestoreSession caught", e);
         });
     }
 }

--- a/extension.js
+++ b/extension.js
@@ -606,11 +606,9 @@ export default class AllWindowsExtension extends Extension {
         this.#windowlist = null;
         this.#allWindowsStates?.destroy();
         this.#allWindowsStates = null;
-        if (this.#dbusImpl) {
-            this.#dbusImpl.flush()
-            this.#dbusImpl.unexport();
-            this.#dbusImpl = null;
-        }
+        this.#dbusImpl?.flush()
+        this.#dbusImpl?.unexport();
+        this.#dbusImpl = null;
         this.#log.debug("disable() ending");
         this.#log = null;
     }

--- a/extension.js
+++ b/extension.js
@@ -613,13 +613,13 @@ export default class AllWindowsExtension extends Extension {
         this.#log = null;
     }
 
-    SaveSession() {
-        console.log("Saving window states...")
-        this.#allWindowsStates.saveWindowPositions("SaveSession triggered via DBus")
+    async SaveSession() {
+        this.#log.log("Saving window states...")
+        await this.#allWindowsStates.saveWindowPositions("SaveSession triggered via DBus")
     }
 
-    RestoreSession() {
-        console.log("Restoring window states...")
-        this.#allWindowsStates.restoreWindowPositions("RestoreSession triggered via DBus")
+    async RestoreSession() {
+        this.#log.log("Restoring window states...")
+        await this.#allWindowsStates.restoreWindowPositions("RestoreSession triggered via DBus", this.#log)
     }
 }


### PR DESCRIPTION
The README.md updates should be sufficient to explain the change. Basically, I like the save/restore window position functionality your extension provides and would like to be able to invoke it in another workflow. This PR enables that.
